### PR TITLE
Visiblesignature

### DIFF
--- a/src/main/java/com/swisscom/ais/TestOnDemandSignatureWithStepUp.java
+++ b/src/main/java/com/swisscom/ais/TestOnDemandSignatureWithStepUp.java
@@ -21,10 +21,12 @@ import com.swisscom.ais.client.model.RevocationInformation;
 import com.swisscom.ais.client.model.SignatureResult;
 import com.swisscom.ais.client.model.SignatureStandard;
 import com.swisscom.ais.client.model.UserData;
+import com.swisscom.ais.client.model.VisibleSignatureDefinition;
 import com.swisscom.ais.client.rest.RestClientConfiguration;
 import com.swisscom.ais.client.rest.RestClientImpl;
 import com.swisscom.ais.client.rest.model.DigestAlgorithm;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -32,7 +34,8 @@ public class TestOnDemandSignatureWithStepUp {
 
     public static void main(String[] args) throws Exception {
         Properties properties = new Properties();
-        properties.load(TestOnDemandSignatureWithStepUp.class.getResourceAsStream("/local-config.properties"));
+
+        properties.load(TestOnDemandSignatureWithStepUp.class.getResourceAsStream("/lambda.properties"));
 
         RestClientConfiguration config = new RestClientConfiguration();
         config.setFromProperties(properties);
@@ -52,6 +55,10 @@ public class TestOnDemandSignatureWithStepUp {
             document.setInputFromFile(properties.getProperty("local.test.inputFile"));
             document.setOutputToFile(properties.getProperty("local.test.outputFilePrefix") + System.currentTimeMillis() + ".pdf");
             document.setDigestAlgorithm(DigestAlgorithm.SHA512);
+            
+            // to create a visible signature in the pdf, specify the signature definition and the page. Optionally, provide an icon that will be embedded in the visual signature
+            document.setVisibleSignatureDefinition(new VisibleSignatureDefinition(200, 200, 150, 30, 0, new File(properties.getProperty("local.test.visibleSignatureFile"))));
+
 
             SignatureResult result = aisClient.signWithOnDemandCertificateAndStepUp(Collections.singletonList(document), userData);
             System.out.println("Final result: " + result);

--- a/src/main/java/com/swisscom/ais/TestOnDemandSignatureWithStepUp.java
+++ b/src/main/java/com/swisscom/ais/TestOnDemandSignatureWithStepUp.java
@@ -33,8 +33,7 @@ public class TestOnDemandSignatureWithStepUp {
 
     public static void main(String[] args) throws Exception {
         Properties properties = new Properties();
-
-        properties.load(TestOnDemandSignatureWithStepUp.class.getResourceAsStream("/build.properties"));
+        properties.load(TestOnDemandSignatureWithStepUp.class.getResourceAsStream("/local-config.properties"));
 
         RestClientConfiguration config = new RestClientConfiguration();
         config.setFromProperties(properties);

--- a/src/main/java/com/swisscom/ais/TestOnDemandSignatureWithStepUp.java
+++ b/src/main/java/com/swisscom/ais/TestOnDemandSignatureWithStepUp.java
@@ -35,7 +35,7 @@ public class TestOnDemandSignatureWithStepUp {
     public static void main(String[] args) throws Exception {
         Properties properties = new Properties();
 
-        properties.load(TestOnDemandSignatureWithStepUp.class.getResourceAsStream("/lambda.properties"));
+        properties.load(TestOnDemandSignatureWithStepUp.class.getResourceAsStream("/build.properties"));
 
         RestClientConfiguration config = new RestClientConfiguration();
         config.setFromProperties(properties);

--- a/src/main/java/com/swisscom/ais/TestOnDemandSignatureWithStepUp.java
+++ b/src/main/java/com/swisscom/ais/TestOnDemandSignatureWithStepUp.java
@@ -26,7 +26,6 @@ import com.swisscom.ais.client.rest.RestClientConfiguration;
 import com.swisscom.ais.client.rest.RestClientImpl;
 import com.swisscom.ais.client.rest.model.DigestAlgorithm;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -57,9 +56,8 @@ public class TestOnDemandSignatureWithStepUp {
             document.setDigestAlgorithm(DigestAlgorithm.SHA512);
             
             // to create a visible signature in the pdf, specify the signature definition and the page. Optionally, provide an icon that will be embedded in the visual signature
-            document.setVisibleSignatureDefinition(new VisibleSignatureDefinition(200, 200, 150, 30, 0, new File(properties.getProperty("local.test.visibleSignatureFile"))));
-
-
+            document.setVisibleSignatureDefinition(new VisibleSignatureDefinition(200, 200, 150, 30, 0, properties.getProperty("local.test.visibleSignatureFile")));
+ 
             SignatureResult result = aisClient.signWithOnDemandCertificateAndStepUp(Collections.singletonList(document), userData);
             System.out.println("Final result: " + result);
         }

--- a/src/main/java/com/swisscom/ais/client/impl/AisClientImpl.java
+++ b/src/main/java/com/swisscom/ais/client/impl/AisClientImpl.java
@@ -22,6 +22,7 @@ import com.swisscom.ais.client.model.PdfHandle;
 import com.swisscom.ais.client.model.SignatureMode;
 import com.swisscom.ais.client.model.SignatureResult;
 import com.swisscom.ais.client.model.UserData;
+import com.swisscom.ais.client.model.VisibleSignatureDefinition;
 import com.swisscom.ais.client.rest.RestClient;
 import com.swisscom.ais.client.rest.model.*;
 import com.swisscom.ais.client.rest.model.pendingreq.AISPendingRequest;
@@ -35,6 +36,7 @@ import com.swisscom.ais.client.utils.Trace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -214,8 +216,9 @@ public class AisClientImpl implements AisClient {
                            trace.getId());
             FileInputStream fileIn = new FileInputStream(documentHandle.getInputFromFile());
             FileOutputStream fileOut = new FileOutputStream(documentHandle.getOutputToFile());
-
-            PdfDocument newDocument = new PdfDocument(documentHandle.getOutputToFile(), fileIn, fileOut, trace);
+            VisibleSignatureDefinition signatureDefinition = documentHandle.getVisibleSignatureDefinition();
+           
+            PdfDocument newDocument = new PdfDocument(documentHandle.getOutputToFile(), fileIn, fileOut, signatureDefinition, trace);
             newDocument.prepareForSigning(documentHandle.getDigestAlgorithm(), signatureType, userData);
             return newDocument;
         } catch (Exception e) {

--- a/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
+++ b/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
@@ -63,10 +63,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 
 import static com.swisscom.ais.client.utils.Utils.closeResource;
@@ -411,16 +409,14 @@ public class PdfDocument implements Closeable {
                 cs.newLineAtOffset(fontSize, height - leading);
                 cs.setLeading(leading);
 
-                Date date = signature.getSignDate().getTime();
-
-                SimpleDateFormat formatter = new SimpleDateFormat("dd.MM.yyyy, HH:mm");
-                String formattedDate = formatter.format(date);
+                // Date date = signature.getSignDate().getTime();
+                // SimpleDateFormat formatter = new SimpleDateFormat("dd.MM.yyyy, HH:mm");
+                // String formattedDate = formatter.format(date);
                 String reason = signature.getReason();
                 // String name = signature.getName();
-
                 // cs.showText("Signer: " + name);
                 // cs.newLine();
-                cs.showText(String.format("%s, %s",reason, formattedDate));
+                cs.showText(reason);
                 // cs.newLine();
                 // cs.showText("Reason: " + reason);
 

--- a/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
+++ b/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
@@ -143,10 +143,10 @@ public class PdfDocument implements Closeable {
 
         // create a visible signature at the specified coordinates
         if (signatureDefinition != null){
-            Rectangle2D humanRect = new Rectangle2D.Float(signatureDefinition.x, signatureDefinition.y, signatureDefinition.width, signatureDefinition.height);
+            Rectangle2D humanRect = new Rectangle2D.Float(signatureDefinition.getX(), signatureDefinition.getY(), signatureDefinition.getWidth(), signatureDefinition.getHeight());
             PDRectangle rect = createSignatureRectangle(pdDocument, humanRect);
-            options.setVisualSignature(createVisualSignatureTemplate(pdDocument, signatureDefinition.page, signatureDefinition.icon, rect, pdSignature));
-            options.setPage(signatureDefinition.page);
+            options.setVisualSignature(createVisualSignatureTemplate(pdDocument, signatureDefinition.getPage(), signatureDefinition.getIconPath(), rect, pdSignature));
+            options.setPage(signatureDefinition.getPage());
         }
 
         pdDocument.addSignature(pdSignature, options);
@@ -322,7 +322,7 @@ public class PdfDocument implements Closeable {
     }
 
     // create a template PDF document with empty signature and return it as a stream.
-    private InputStream createVisualSignatureTemplate(PDDocument srcDoc, int pageNum, File image, PDRectangle rect, PDSignature signature) throws IOException {
+    private InputStream createVisualSignatureTemplate(PDDocument srcDoc, int pageNum, String iconPath, PDRectangle rect, PDSignature signature) throws IOException {
         try (PDDocument doc = new PDDocument()) {
             PDPage page = new PDPage(srcDoc.getPage(pageNum).getMediaBox());
             doc.addPage(page);
@@ -390,7 +390,9 @@ public class PdfDocument implements Closeable {
                 // cs.addRect(-5000, -5000, 10000, 10000);
                 // cs.fill();
 
-                if (image != null) {
+                File image = new File(iconPath);
+
+                if (image != null && image.exists()) {
                     // show background image
                     // save and restore graphics if the image is too large and needs to be scaled
                     cs.saveGraphicsState();

--- a/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
+++ b/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
@@ -418,11 +418,13 @@ public class PdfDocument implements Closeable {
                 cs.showText(String.format("%s %s", reason, formattedDate));
 
                 cs.endText();
+                cs.close();
             }
 
             // no need to set annotations and /P entry
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             doc.save(baos);
+            doc.close();
             return new ByteArrayInputStream(baos.toByteArray());
         }
     }

--- a/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
+++ b/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
@@ -160,6 +160,7 @@ public class PdfDocument implements Closeable {
         MessageDigest digest = MessageDigest.getInstance(digestAlgorithm.getDigestAlgorithm());
         byte[] contentToSign = IOUtils.toByteArray(pbSigningSupport.getContent());
         byte[] hashToSign = digest.digest(contentToSign);
+        options.close();
         base64HashToSign = Base64.getEncoder().encodeToString(hashToSign);
     }
 
@@ -418,13 +419,12 @@ public class PdfDocument implements Closeable {
                 cs.showText(String.format("%s %s", reason, formattedDate));
 
                 cs.endText();
-                cs.close();
             }
 
             // no need to set annotations and /P entry
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             doc.save(baos);
-            doc.close();
+            
             return new ByteArrayInputStream(baos.toByteArray());
         }
     }

--- a/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
+++ b/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
@@ -17,6 +17,7 @@ package com.swisscom.ais.client.impl;
 
 import com.swisscom.ais.client.AisClientException;
 import com.swisscom.ais.client.model.UserData;
+import com.swisscom.ais.client.model.VisibleSignatureDefinition;
 import com.swisscom.ais.client.rest.model.DigestAlgorithm;
 import com.swisscom.ais.client.rest.model.SignatureType;
 import com.swisscom.ais.client.utils.Trace;
@@ -28,22 +29,44 @@ import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.common.PDStream;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceDictionary;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceStream;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.ExternalSigningSupport;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSeedValue;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSeedValueMDP;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureOptions;
+import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+import org.apache.pdfbox.pdmodel.interactive.form.PDField;
 import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
+import org.apache.pdfbox.util.Matrix;
 
+import java.awt.Color;
+import java.awt.geom.Rectangle2D;
+import java.awt.geom.AffineTransform;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import static com.swisscom.ais.client.utils.Utils.closeResource;
@@ -52,6 +75,7 @@ public class PdfDocument implements Closeable {
 
     private final InputStream contentIn;
     private final OutputStream contentOut;
+    private final VisibleSignatureDefinition signatureDefinition;
     private final ByteArrayOutputStream inMemoryStream;
     private final String name;
     private final Trace trace;
@@ -64,10 +88,12 @@ public class PdfDocument implements Closeable {
 
     // ----------------------------------------------------------------------------------------------------
 
-    public PdfDocument(String name, InputStream contentIn, OutputStream contentOut, Trace trace) {
+    public PdfDocument(String name, InputStream contentIn, OutputStream contentOut, VisibleSignatureDefinition signatureDefinition, Trace trace) {
         this.name = name;
         this.contentIn = contentIn;
         this.contentOut = contentOut;
+        this.signatureDefinition = signatureDefinition;
+        
         this.inMemoryStream = new ByteArrayOutputStream();
         this.trace = trace;
     }
@@ -113,6 +139,15 @@ public class PdfDocument implements Closeable {
 
         SignatureOptions options = new SignatureOptions();
         options.setPreferredSignatureSize(signatureType.getEstimatedSignatureSizeInBytes());
+
+
+        // create a visible signature at the specified coordinates
+        if (signatureDefinition != null){
+            Rectangle2D humanRect = new Rectangle2D.Float(signatureDefinition.x, signatureDefinition.y, signatureDefinition.width, signatureDefinition.height);
+            PDRectangle rect = createSignatureRectangle(pdDocument, humanRect);
+            options.setVisualSignature(createVisualSignatureTemplate(pdDocument, signatureDefinition.page, signatureDefinition.icon, rect, pdSignature));
+            options.setPage(signatureDefinition.page);
+        }
 
         pdDocument.addSignature(pdSignature, options);
         // Set this signature's access permissions level to 0, to ensure we just sign the PDF not certify it
@@ -243,5 +278,159 @@ public class PdfDocument implements Closeable {
     public DigestAlgorithm getDigestAlgorithm() {
         return digestAlgorithm;
     }
+
+
+    // ----------------------------------------------------------------------------------------------------
+
+    private PDRectangle createSignatureRectangle(PDDocument doc, Rectangle2D humanRect) {
+        float x = (float) humanRect.getX();
+        float y = (float) humanRect.getY();
+        float width = (float) humanRect.getWidth();
+        float height = (float) humanRect.getHeight();
+        PDPage page = doc.getPage(0);
+        PDRectangle pageRect = page.getCropBox();
+        PDRectangle rect = new PDRectangle();
+        // signing should be at the same position regardless of page rotation.
+        switch (page.getRotation()) {
+            case 90:
+                rect.setLowerLeftY(x);
+                rect.setUpperRightY(x + width);
+                rect.setLowerLeftX(y);
+                rect.setUpperRightX(y + height);
+                break;
+            case 180:
+                rect.setUpperRightX(pageRect.getWidth() - x);
+                rect.setLowerLeftX(pageRect.getWidth() - x - width);
+                rect.setLowerLeftY(y);
+                rect.setUpperRightY(y + height);
+                break;
+            case 270:
+                rect.setLowerLeftY(pageRect.getHeight() - x - width);
+                rect.setUpperRightY(pageRect.getHeight() - x);
+                rect.setLowerLeftX(pageRect.getWidth() - y - height);
+                rect.setUpperRightX(pageRect.getWidth() - y);
+                break;
+            case 0:
+            default:
+                rect.setLowerLeftX(x);
+                rect.setUpperRightX(x + width);
+                rect.setLowerLeftY(pageRect.getHeight() - y - height);
+                rect.setUpperRightY(pageRect.getHeight() - y);
+                break;
+        }
+        return rect;
+    }
+
+    // create a template PDF document with empty signature and return it as a stream.
+    private InputStream createVisualSignatureTemplate(PDDocument srcDoc, int pageNum, File image, PDRectangle rect, PDSignature signature) throws IOException {
+        try (PDDocument doc = new PDDocument()) {
+            PDPage page = new PDPage(srcDoc.getPage(pageNum).getMediaBox());
+            doc.addPage(page);
+            PDAcroForm acroForm = new PDAcroForm(doc);
+            doc.getDocumentCatalog().setAcroForm(acroForm);
+            PDSignatureField signatureField = new PDSignatureField(acroForm);
+            PDAnnotationWidget widget = signatureField.getWidgets().get(0);
+            List<PDField> acroFormFields = acroForm.getFields();
+            acroForm.setSignaturesExist(true);
+            acroForm.setAppendOnly(true);
+            acroForm.getCOSObject().setDirect(true);
+            acroFormFields.add(signatureField);
+
+            widget.setRectangle(rect);
+
+            // from PDVisualSigBuilder.createHolderForm()
+            PDStream stream = new PDStream(doc);
+            PDFormXObject form = new PDFormXObject(stream);
+            PDResources res = new PDResources();
+            form.setResources(res);
+            form.setFormType(1);
+            PDRectangle bbox = new PDRectangle(rect.getWidth(), rect.getHeight());
+            float height = bbox.getHeight();
+            Matrix initialScale = null;
+            switch (srcDoc.getPage(pageNum).getRotation()) {
+                case 90:
+                    form.setMatrix(AffineTransform.getQuadrantRotateInstance(1));
+                    initialScale = Matrix.getScaleInstance(bbox.getWidth() / bbox.getHeight(),
+                            bbox.getHeight() / bbox.getWidth());
+                    height = bbox.getWidth();
+                    break;
+                case 180:
+                    form.setMatrix(AffineTransform.getQuadrantRotateInstance(2));
+                    break;
+                case 270:
+                    form.setMatrix(AffineTransform.getQuadrantRotateInstance(3));
+                    initialScale = Matrix.getScaleInstance(bbox.getWidth() / bbox.getHeight(),
+                            bbox.getHeight() / bbox.getWidth());
+                    height = bbox.getWidth();
+                    break;
+                case 0:
+                default:
+                    break;
+            }
+            form.setBBox(bbox);
+            PDFont font = PDType1Font.HELVETICA_BOLD;
+
+            // from PDVisualSigBuilder.createAppearanceDictionary()
+            PDAppearanceDictionary appearance = new PDAppearanceDictionary();
+            appearance.getCOSObject().setDirect(true);
+            PDAppearanceStream appearanceStream = new PDAppearanceStream(form.getCOSObject());
+            appearance.setNormalAppearance(appearanceStream);
+            widget.setAppearance(appearance);
+
+            try (PDPageContentStream cs = new PDPageContentStream(doc, appearanceStream)) {
+                // for 90° and 270° scale ratio of width / height
+                // not really sure about this
+                // why does scale have no effect when done in the form matrix???
+                if (initialScale != null) {
+                    cs.transform(initialScale);
+                }
+
+                // show background (just for debugging, to see the rect size + position)
+                // cs.setNonStrokingColor(Color.yellow);
+                // cs.addRect(-5000, -5000, 10000, 10000);
+                // cs.fill();
+
+                if (image != null) {
+                    // show background image
+                    // save and restore graphics if the image is too large and needs to be scaled
+                    cs.saveGraphicsState();
+                    cs.transform(Matrix.getScaleInstance(0.25f, 0.25f));
+                    PDImageXObject img = PDImageXObject.createFromFileByExtension(image, doc);
+                    cs.drawImage(img, 0, 0);
+                    cs.restoreGraphicsState();
+                }
+
+                // show text
+                float fontSize = 8;
+                float leading = fontSize * 1.5f;
+                cs.beginText();
+                cs.setFont(font, fontSize);
+                cs.setNonStrokingColor(Color.black);
+                cs.newLineAtOffset(fontSize, height - leading);
+                cs.setLeading(leading);
+
+                Date date = signature.getSignDate().getTime();
+
+                SimpleDateFormat formatter = new SimpleDateFormat("dd.MM.yyyy, HH:mm");
+                String formattedDate = formatter.format(date);
+                String reason = signature.getReason();
+                // String name = signature.getName();
+
+                // cs.showText("Signer: " + name);
+                // cs.newLine();
+                cs.showText(String.format("%s, %s",reason, formattedDate));
+                // cs.newLine();
+                // cs.showText("Reason: " + reason);
+
+                cs.endText();
+            }
+
+            // no need to set annotations and /P entry
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            doc.save(baos);
+            return new ByteArrayInputStream(baos.toByteArray());
+        }
+    }
+
 
 }

--- a/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
+++ b/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
@@ -63,6 +63,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Calendar;
 import java.util.List;
@@ -409,16 +412,18 @@ public class PdfDocument implements Closeable {
                 cs.newLineAtOffset(fontSize, height - leading);
                 cs.setLeading(leading);
 
-                // Date date = signature.getSignDate().getTime();
-                // SimpleDateFormat formatter = new SimpleDateFormat("dd.MM.yyyy, HH:mm");
-                // String formattedDate = formatter.format(date);
+                Calendar cal = signature.getSignDate();
+                ZoneId zoneId = ZoneId.of("Europe/Berlin");
+                LocalDateTime localDateTime = LocalDateTime.ofInstant(cal.toInstant(), zoneId);
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy, HH:mm:ss");
+
+                String formattedDate = localDateTime.format(formatter);
                 String reason = signature.getReason();
                 // String name = signature.getName();
                 // cs.showText("Signer: " + name);
                 // cs.newLine();
+                cs.showText(String.format("%s, %s", reason, formattedDate));
                 cs.showText(reason);
-                // cs.newLine();
-                // cs.showText("Reason: " + reason);
 
                 cs.endText();
             }

--- a/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
+++ b/src/main/java/com/swisscom/ais/client/impl/PdfDocument.java
@@ -386,11 +386,6 @@ public class PdfDocument implements Closeable {
                     cs.transform(initialScale);
                 }
 
-                // show background (just for debugging, to see the rect size + position)
-                // cs.setNonStrokingColor(Color.yellow);
-                // cs.addRect(-5000, -5000, 10000, 10000);
-                // cs.fill();
-
                 File image = new File(iconPath);
 
                 if (image != null && image.exists()) {
@@ -419,11 +414,8 @@ public class PdfDocument implements Closeable {
 
                 String formattedDate = localDateTime.format(formatter);
                 String reason = signature.getReason();
-                // String name = signature.getName();
-                // cs.showText("Signer: " + name);
-                // cs.newLine();
-                cs.showText(String.format("%s, %s", reason, formattedDate));
-                cs.showText(reason);
+  
+                cs.showText(String.format("%s %s", reason, formattedDate));
 
                 cs.endText();
             }

--- a/src/main/java/com/swisscom/ais/client/model/PdfHandle.java
+++ b/src/main/java/com/swisscom/ais/client/model/PdfHandle.java
@@ -29,6 +29,8 @@ public class PdfHandle {
 
     private DigestAlgorithm digestAlgorithm = DigestAlgorithm.SHA512;
 
+    private VisibleSignatureDefinition visibleSignatureDefinition = null;
+
     public String getInputFromFile() {
         return inputFromFile;
     }
@@ -51,6 +53,14 @@ public class PdfHandle {
 
     public void setDigestAlgorithm(DigestAlgorithm digestAlgorithm) {
         this.digestAlgorithm = digestAlgorithm;
+    }
+
+    public VisibleSignatureDefinition getVisibleSignatureDefinition() {
+        return visibleSignatureDefinition;
+    }
+
+    public void setVisibleSignatureDefinition(VisibleSignatureDefinition definition) {
+        this.visibleSignatureDefinition = definition;
     }
 
     public void validateYourself(Trace trace) {

--- a/src/main/java/com/swisscom/ais/client/model/VisibleSignatureDefinition.java
+++ b/src/main/java/com/swisscom/ais/client/model/VisibleSignatureDefinition.java
@@ -1,40 +1,69 @@
-/*
- * Copyright 2021 Swisscom Trust Services (Schweiz) AG
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.swisscom.ais.client.model;
-
-import java.io.File;
 
 public class VisibleSignatureDefinition {
 
-    public int x;
-    public int y;
-    public int width;
-    public int height;
-    public int page;
+    private int x = 0;
+    private int y = 0;
+    private int width = 150;
+    private int height = 50;
+    private int page = 0;
+    private String iconPath;
 
-    public File icon;
-
-    public VisibleSignatureDefinition(int x, int y,int width, int height, int page, File icon){
-        this.x = x;
-        this.y = y;
-        this.width = width;
-        this.height = height;
-        this.page= page;
-        this.icon = icon;
+    public VisibleSignatureDefinition(){}
+    public VisibleSignatureDefinition(int x, int y, int width, int height, int page, String iconPath){
+        this.setX(x);
+        this.setY(y);
+        this.setWidth(width);
+        this.setHeight(height);
+        this.setPage(page);
+        this.setIconPath(iconPath);
     }
 
+    public String getIconPath() {
+        return iconPath;
+    }
 
+    public void setIconPath(String iconPath) {
+        this.iconPath = iconPath;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
 }

--- a/src/main/java/com/swisscom/ais/client/model/VisibleSignatureDefinition.java
+++ b/src/main/java/com/swisscom/ais/client/model/VisibleSignatureDefinition.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Swisscom Trust Services (Schweiz) AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.swisscom.ais.client.model;
+
+import java.io.File;
+
+public class VisibleSignatureDefinition {
+
+    public int x;
+    public int y;
+    public int width;
+    public int height;
+    public int page;
+
+    public File icon;
+
+    public VisibleSignatureDefinition(int x, int y,int width, int height, int page, File icon){
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+        this.page= page;
+        this.icon = icon;
+    }
+
+
+}


### PR DESCRIPTION
### Summary
Allows creating a visible signature in the signed pdf.

![image](https://user-images.githubusercontent.com/16301487/118653549-f32be280-b7e7-11eb-8585-ce1cf282fbf4.png)

You can create a text only signature or optinally provide an image that will be inserted in the pdf signature.

### Example
See the example in TestOnDemandSignatureWithStepUp.java:

Parameters are: x, y, width, height, pageNumber

```java
document.setVisibleSignatureDefinition(new VisibleSignatureDefinition(200, 200, 150, 30, 0, new File(properties.getProperty("local.test.visibleSignatureFile"))));
```


